### PR TITLE
Add space as a trigger

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { HexCompletion } from './HexCompletion';
 export function activate(context: vscode.ExtensionContext) {
     const provider = new HexCompletion();
     const selector = ["elixir", "Elixir"];
-    const triggers = ['"'];
+    const triggers = ['"', ' '];
     const hexCompletion = vscode.languages.registerCompletionItemProvider(selector, provider, ...triggers);
 
     context.subscriptions.push(hexCompletion);

--- a/src/shouldProvide.ts
+++ b/src/shouldProvide.ts
@@ -5,7 +5,9 @@ export function shouldProvide(
   position: vscode.Position
 ): boolean {
   return (
-    isMixfile(document.fileName) && isCursorInDepsBlock(document, position)
+    isMixfile(document.fileName) &&
+    isCursorInDepsBlock(document, position) &&
+    isCursorInString(document, position)
   );
 }
 
@@ -32,6 +34,27 @@ function isCursorInDepsBlock(
   const depsEndRegex = /^[\s]*end$/m;
   if (depsHeadToCursor.search(depsEndRegex) > -1) {
     // assumes `end` does not appear by itself in a line in deps block
+    return false;
+  }
+
+  return true;
+}
+
+function isCursorInString(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): boolean {
+  const line = document.lineAt(position.line);
+
+  const leftText = document.getText(
+    new vscode.Range(line.range.start, position)
+  );
+
+  const rightText = document.getText(
+    new vscode.Range(position, line.range.end)
+  );
+
+  if (leftText.indexOf('"') === -1 || rightText.indexOf('"') === -1) {
     return false;
   }
 


### PR DESCRIPTION
Hi,
First of all, thanks for building this extension, it's really helpful.

I decided to add space to the triggers, my use case is this:

`{:jason, "~> (suggestions tooltip/dropdown)`"

Currently, you have to move your a cursor all the way back after inserting a version and then add `~>` which is just a tad annoying. Trigger on a space would allow a better UX (in my opinion).

Wdyt?