### PR TITLE
Use a pattern to select the mix.exs files (optimization)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,14 +5,20 @@ import * as vscode from 'vscode';
 import { HexCompletion } from './HexCompletion';
 
 export function activate(context: vscode.ExtensionContext) {
-    const provider = new HexCompletion();
-    const selector = ["elixir", "Elixir"];
-    const triggers = ['"', ' '];
-    const hexCompletion = vscode.languages.registerCompletionItemProvider(selector, provider, ...triggers);
+  const provider = new HexCompletion();
+  const selector = [
+    { language: 'elixir', pattern: '**/mix.exs' },
+    { language: 'Elixir', pattern: '**/mix.exs' },
+  ];
+  const triggers = ['"', ' '];
+  const hexCompletion = vscode.languages.registerCompletionItemProvider(
+    selector,
+    provider,
+    ...triggers
+  );
 
-    context.subscriptions.push(hexCompletion);
+  context.subscriptions.push(hexCompletion);
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {
-}
+export function deactivate() {}

--- a/src/shouldProvide.ts
+++ b/src/shouldProvide.ts
@@ -5,14 +5,9 @@ export function shouldProvide(
   position: vscode.Position
 ): boolean {
   return (
-    isMixfile(document.fileName) &&
     isCursorInDepsBlock(document, position) &&
     isCursorInString(document, position)
   );
-}
-
-function isMixfile(fileName: String): boolean {
-  return fileName.endsWith('mix.exs');
 }
 
 function isCursorInDepsBlock(


### PR DESCRIPTION
I've been working on package name intellisense and going through the docs I noticed that there is a bit better (native) way of running it only in `mix.exs` files. Tested it locally and it works, so maybe you will consider my changes. 

Here is an example with package.json:
https://code.visualstudio.com/api/references/vscode-api#DocumentFilter

I will open a separate PR for the package name intellisense over the coming weekend.